### PR TITLE
feat(webhook): add validating admission webhook for ScalePolicy CRD

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"crypto/tls"
+	"log"
+	"net/http"
+	"github.com/ShivamJha2436/kubehalo/internal/webhook"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/validate", webhook.Serve)
+
+	// TLS cert and key (mounted from Secret)
+	certFile := "/tls/tls.crt"
+	keyFile := "/tls/tls.key"
+
+	server := &http.Server{
+		Addr:      ":8443",
+		TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+		Handler:   mux,
+	}
+
+	log.Println("[webhook] starting on :8443/validate")
+	if err := server.ListenAndServeTLS(certFile, keyFile); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/config/webhook/webhook.yaml
+++ b/config/webhook/webhook.yaml
@@ -1,0 +1,19 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: scalepolicy-webhook
+webhooks:
+  - name: scalepolicy.kubehalo.sh
+    rules:
+      - apiGroups: ["kubehalo.sh"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["scalepolicies"]
+    clientConfig:
+      service:
+        name: kubehalo-webhook
+        namespace: default
+        path: "/validate"
+      caBundle: <BASE64_CA_CERT>
+    admissionReviewVersions: ["v1"]
+    sideEffects: None

--- a/internal/webhook/validate.go
+++ b/internal/webhook/validate.go
@@ -1,0 +1,68 @@
+package webhook
+
+import (
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"github.com/ShivamJha2436/kubehalo/api/v1"
+)
+
+var (
+	codecs = serializer.NewCodecFactory(runtime.NewScheme())
+	deserializer = codecs.UniversalDeserializer()
+)
+
+// validateScalePolicy checks ScalePolicy rules
+func validateScalePolicy(sp *v1.ScalePolicy) error {
+	if sp.Spec.MetricQuery == "" {
+		return fmt.Errorf("metricQuery must not be empty")
+	}
+	if sp.Spec.Threshold <= 0 {
+		return fmt.Errorf("threshold must be > 0")
+	}
+	if sp.Spec.ScaleTargetRef.Name == "" || sp.Spec.ScaleTargetRef.Kind == "" {
+		return fmt.Errorf("scaleTargetRef must include kind and name")
+	}
+	return nil
+}
+
+// Serve handles admission requests
+func Serve(w http.ResponseWriter, r *http.Request) {
+	var review admissionv1.AdmissionReview
+	if err := json.NewDecoder(r.Body).Decode(&review); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	req := review.Request
+	var sp v1.ScalePolicy
+	if _, _, err := deserializer.Decode(req.Object.Raw, nil, &sp); err != nil {
+		writeResponse(w, review, false, fmt.Sprintf("cannot decode object: %v", err))
+		return
+	}
+
+	// Run validation
+	if err := validateScalePolicy(&sp); err != nil {
+		writeResponse(w, review, false, err.Error())
+		return
+	}
+
+	writeResponse(w, review, true, "allowed")
+}
+
+func writeResponse(w http.ResponseWriter, review admissionv1.AdmissionReview, allowed bool, msg string) {
+	response := admissionv1.AdmissionReview{
+		TypeMeta: review.TypeMeta,
+		Response: &admissionv1.AdmissionResponse{
+			UID:     review.Request.UID,
+			Allowed: allowed,
+			Result: &metav1.Status{
+				Message: msg,
+			},
+		},
+	}
+	_ = json.NewEncoder(w).Encode(response)
+}


### PR DESCRIPTION
# ScalePolicy Validation Webhook

This commit introduces a **Validating Admission Webhook** for the `ScalePolicy` CRD to ensure that misconfigured or invalid resources are rejected before being persisted in Kubernetes.

## ✨ New Features
- Added webhook server (`cmd/webhook`) with `/validate` endpoint.
- Implemented validation logic in `internal/webhook/validate.go`.
- Introduced new manifests under `config/webhook/`:
  - `webhook.yaml` → `ValidatingWebhookConfiguration`
  - `service.yaml` → Service for webhook server
  - TLS Secret + Deployment support (self-signed certs)

## ✅ Validation Rules
- `spec.metricQuery` must not be empty.
- `spec.threshold` must be greater than `0`.
- `spec.scaleTargetRef` must include both `kind` and `name`.

## 🔒 Security
- Webhook server runs on HTTPS (`:8443`) with TLS certificates mounted from a Kubernetes Secret.

## 🧪 Testing
1. Deploy webhook server (`cmd/webhook` → Deployment + Service).
2. Apply `ValidatingWebhookConfiguration`.
3. Try applying invalid `ScalePolicy` objects:
   - Missing threshold → rejected
   - Empty metricQuery → rejected
4. Apply valid `ScalePolicy` → accepted.

This ensures that invalid scaling configurations are **caught early** and do not cause runtime failures in the controller.
